### PR TITLE
stripe.json: use the color names used in Stripe's 'Designing accessible color systems'

### DIFF
--- a/src/shared/presets/stripe.json
+++ b/src/shared/presets/stripe.json
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "name": "teal",
+      "name": "cyan",
       "colors": [
         "#eefdfe",
         "#cff3fb",
@@ -47,7 +47,7 @@
       ]
     },
     {
-      "name": "emerald",
+      "name": "green",
       "colors": [
         "#f2feee",
         "#cff7c9",
@@ -62,7 +62,7 @@
       ]
     },
     {
-      "name": "orange",
+      "name": "yellow",
       "colors": [
         "#fbf9ea",
         "#f6e4ba",
@@ -77,7 +77,7 @@
       ]
     },
     {
-      "name": "chestnut",
+      "name": "orange",
       "colors": [
         "#fefaee",
         "#fce2c0",
@@ -92,7 +92,7 @@
       ]
     },
     {
-      "name": "cerise",
+      "name": "red",
       "colors": [
         "#fef7f4",
         "#fbe0dd",
@@ -122,7 +122,7 @@
       ]
     },
     {
-      "name": "indigo",
+      "name": "violet",
       "colors": [
         "#f8f9fe",
         "#e7e5fc",


### PR DESCRIPTION
https://stripe.com/blog/accessible-color-systems uses the more generic color names.

This was prompted by me noticing that "teal" did not seem to describe the cyan color in the Stripe preset.