### PR TITLE
feat: editable graph labels

### DIFF
--- a/src/components/ColorGraph/index.tsx
+++ b/src/components/ColorGraph/index.tsx
@@ -77,10 +77,9 @@ export function Scale({
               if (active instanceof HTMLInputElement) active.blur()
             }}
             onKeyDown={e => {
-              const el = e.currentTarget
-              if (e.key === 'Enter' || e.key === 'Escape') el.blur()
-              else if (e.key === 'ArrowUp') el.stepUp(ranges[channel].step)
-              else if (e.key === 'ArrowDown') el.stepDown(ranges[channel].step)
+              if (e.key === 'Enter' || e.key === 'Escape') {
+                e.currentTarget.blur()
+              }
             }}
             onFocus={e => {
               onSelect(i)

--- a/src/components/ColorGraph/index.tsx
+++ b/src/components/ColorGraph/index.tsx
@@ -6,6 +6,7 @@ import { colorSpaceStore } from 'store/palette'
 import { chartSettingsStore } from 'store/chartSettings'
 import type { ChangeEvent } from 'react'
 import { Canvas } from './Chart/Canvas'
+import { clamp } from 'shared/utils'
 
 type ScaleProps = {
   colors: TColor[]
@@ -31,16 +32,12 @@ export function Scale({
   if (!colors?.length) return null
   const sectionWidth = width / colors.length
 
-  const onChange = (
-    e: ChangeEvent<HTMLInputElement>,
-    color: TColor,
-    i: number
-  ) => {
+  const setColor = (color: TColor, idx: number, value: number) => {
     const { l, c, h } = color
-    const value = +e.target.value
-    if (channel === 'l') onColorChange(i, [value, c, h])
-    if (channel === 'c') onColorChange(i, [l, value, h])
-    if (channel === 'h') onColorChange(i, [l, c, value])
+    value = clamp(value, ranges[channel].min, ranges[channel].max)
+    if (channel === 'l') onColorChange(idx, [value, c, h])
+    if (channel === 'c') onColorChange(idx, [l, value, h])
+    if (channel === 'h') onColorChange(idx, [l, c, value])
   }
 
   return (
@@ -82,14 +79,14 @@ export function Scale({
             onKeyDown={e => {
               const el = e.currentTarget
               if (e.key === 'Enter' || e.key === 'Escape') el.blur()
-              if (e.key === 'ArrowUp') el.stepUp(ranges[channel].step)
-              if (e.key === 'ArrowDown') el.stepDown(ranges[channel].step)
+              else if (e.key === 'ArrowUp') el.stepUp(ranges[channel].step)
+              else if (e.key === 'ArrowDown') el.stepDown(ranges[channel].step)
             }}
             onFocus={e => {
               onSelect(i)
               setTimeout(() => e.target.select(), 0)
             }}
-            onChange={e => onChange(e, color, i)}
+            onChange={e => setColor(color, i, +e.target.value)}
           />
         ))}
       </div>
@@ -118,7 +115,7 @@ export function Scale({
               max={ranges[channel].max}
               step={ranges[channel].step}
               value={color[channel]}
-              onChange={e => onChange(e, color, i)}
+              onChange={e => setColor(color, i, +e.target.value)}
               onClick={() => onSelect(i)}
               isSelected={i === selected}
               style={{

--- a/src/components/ColorGraph/index.tsx
+++ b/src/components/ColorGraph/index.tsx
@@ -4,6 +4,7 @@ import { getMostContrast } from 'shared/color'
 import { Channel, LCH, TColor } from 'shared/types'
 import { colorSpaceStore } from 'store/palette'
 import { chartSettingsStore } from 'store/chartSettings'
+import type { ChangeEvent } from 'react'
 import { Canvas } from './Chart/Canvas'
 
 type ScaleProps = {
@@ -29,6 +30,19 @@ export function Scale({
   const { ranges } = useStore(colorSpaceStore)
   if (!colors?.length) return null
   const sectionWidth = width / colors.length
+
+  const onChange = (
+    e: ChangeEvent<HTMLInputElement>,
+    color: TColor,
+    i: number
+  ) => {
+    const { l, c, h } = color
+    const value = +e.target.value
+    if (channel === 'l') onColorChange(i, [value, c, h])
+    if (channel === 'c') onColorChange(i, [l, value, h])
+    if (channel === 'h') onColorChange(i, [l, c, value])
+  }
+
   return (
     <div
       style={{
@@ -45,9 +59,38 @@ export function Scale({
         }}
       >
         {colors.map((color, i) => (
-          <Value key={i} color={color.hex} onClick={() => onSelect(i)}>
-            {+color[channel].toFixed(1)}
-          </Value>
+          <ValueInput
+            key={i}
+            type="number"
+            color={color.hex}
+            title={color[channel].toFixed(ranges[channel].precision)}
+            min={ranges[channel].min}
+            max={ranges[channel].max}
+            step={ranges[channel].step}
+            value={
+              +color[channel].toFixed(
+                i === selected ? ranges[channel].precision : 1
+              )
+            }
+            onMouseDown={e => {
+              if (i === selected || e.ctrlKey) return
+              e.preventDefault()
+              onSelect(i)
+              const active = document.activeElement
+              if (active instanceof HTMLInputElement) active.blur()
+            }}
+            onKeyDown={e => {
+              const el = e.currentTarget
+              if (e.key === 'Enter' || e.key === 'Escape') el.blur()
+              if (e.key === 'ArrowUp') el.stepUp(ranges[channel].step)
+              if (e.key === 'ArrowDown') el.stepDown(ranges[channel].step)
+            }}
+            onFocus={e => {
+              onSelect(i)
+              setTimeout(() => e.target.select(), 0)
+            }}
+            onChange={e => onChange(e, color, i)}
+          />
         ))}
       </div>
       <div
@@ -75,13 +118,7 @@ export function Scale({
               max={ranges[channel].max}
               step={ranges[channel].step}
               value={color[channel]}
-              onChange={e => {
-                const { l, c, h } = color
-                const value = +e.target.value
-                if (channel === 'l') onColorChange(i, [value, c, h])
-                if (channel === 'c') onColorChange(i, [l, value, h])
-                if (channel === 'h') onColorChange(i, [l, c, value])
-              }}
+              onChange={e => onChange(e, color, i)}
               onClick={() => onSelect(i)}
               isSelected={i === selected}
               style={{
@@ -99,15 +136,38 @@ export function Scale({
   )
 }
 
-const Value = styled.div<{ color: string }>`
+const ValueInput = styled.input<{
+  color: string
+}>`
+  --c-contrasting: ${p => getMostContrast(p.color, ['black', 'white'])};
   background-color: ${p => p.color};
-  color: ${p => getMostContrast(p.color, ['black', 'white'])};
+  color: var(--c-contrasting);
   text-align: center;
   font-size: 12px;
-  line-height: 24px;
+  line-height: 20px;
   padding: 0;
   min-width: 0;
   flex: 1 0;
+  border: 2px solid transparent;
+
+  :first-child {
+    border-radius: 8px 0 0 0;
+  }
+  :last-child {
+    border-radius: 0 8px 0 0;
+  }
+
+  :focus {
+    outline: none;
+    border-color: var(--c-contrasting);
+  }
+
+  -moz-appearance: textfield;
+  ::-webkit-outer-spin-button,
+  ::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
 `
 
 const Knob = styled.input.attrs({ type: 'range' })<{

--- a/src/components/Header/ColorEditor.tsx
+++ b/src/components/Header/ColorEditor.tsx
@@ -28,8 +28,8 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           type="number"
           min={ranges.l.min}
           max={ranges.l.max}
-          value={+l.toFixed(2)}
           step={ranges.l.step}
+          value={+l.toFixed(ranges.l.precision)}
           onChange={e => onChange(lch2color([+e.target.value, c, h]))}
         />
       </ChannelInputWrapper>
@@ -39,8 +39,8 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           type="number"
           min={ranges.c.min}
           max={ranges.c.max}
-          value={+c.toFixed(2)}
           step={ranges.c.step}
+          value={+c.toFixed(ranges.c.precision)}
           onChange={e => onChange(lch2color([l, +e.target.value, h]))}
         />
       </ChannelInputWrapper>
@@ -50,8 +50,8 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           type="number"
           min={ranges.h.min}
           max={ranges.h.max}
-          value={+h.toFixed(2)}
           step={ranges.h.step}
+          value={+h.toFixed(ranges.h.precision)}
           onChange={e => onChange(lch2color([l, c, +e.target.value]))}
         />
       </ChannelInputWrapper>

--- a/src/components/Header/ColorEditor.tsx
+++ b/src/components/Header/ColorEditor.tsx
@@ -28,8 +28,8 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           type="number"
           min={ranges.l.min}
           max={ranges.l.max}
-          step={0.5}
           value={+l.toFixed(2)}
+          step={ranges.l.step}
           onChange={e => onChange(lch2color([+e.target.value, c, h]))}
         />
       </ChannelInputWrapper>
@@ -39,8 +39,8 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           type="number"
           min={ranges.c.min}
           max={ranges.c.max}
-          step={0.5}
           value={+c.toFixed(2)}
+          step={ranges.c.step}
           onChange={e => onChange(lch2color([l, +e.target.value, h]))}
         />
       </ChannelInputWrapper>
@@ -50,8 +50,8 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           type="number"
           min={ranges.h.min}
           max={ranges.h.max}
-          step={0.5}
           value={+h.toFixed(2)}
+          step={ranges.h.step}
           onChange={e => onChange(lch2color([l, c, +e.target.value]))}
         />
       </ChannelInputWrapper>

--- a/src/components/Header/ColorEditor.tsx
+++ b/src/components/Header/ColorEditor.tsx
@@ -48,7 +48,7 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
         <ChannelLabel>H</ChannelLabel>
         <ChannelInput
           type="number"
-          min={ranges.c.min}
+          min={ranges.h.min}
           max={ranges.h.max}
           step={0.5}
           value={+h.toFixed(2)}

--- a/src/components/Header/ColorEditor.tsx
+++ b/src/components/Header/ColorEditor.tsx
@@ -1,9 +1,10 @@
 import React, { FC, useEffect, useState } from 'react'
 import styled from 'styled-components'
-import { TColor } from 'shared/types'
+import { Channel, TColor } from 'shared/types'
 import { ControlGroup, Input } from '../inputs'
 import { useStore } from '@nanostores/react'
 import { colorSpaceStore } from 'store/palette'
+import { clamp } from 'shared/utils'
 
 type ColorEditorProps = {
   color: TColor
@@ -20,6 +21,13 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
     if (!isFocused) setColorInput(hex)
   }, [hex, isFocused])
 
+  const setColor = (channel: Channel, value: number) => {
+    value = clamp(value, ranges[channel].min, ranges[channel].max)
+    if (channel === 'l') onChange(lch2color([value, c, h]))
+    if (channel === 'c') onChange(lch2color([l, value, h]))
+    if (channel === 'h') onChange(lch2color([l, c, value]))
+  }
+
   return (
     <ControlGroup>
       <ChannelInputWrapper>
@@ -30,7 +38,7 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           max={ranges.l.max}
           step={ranges.l.step}
           value={+l.toFixed(ranges.l.precision)}
-          onChange={e => onChange(lch2color([+e.target.value, c, h]))}
+          onChange={e => setColor('l', +e.target.value)}
         />
       </ChannelInputWrapper>
       <ChannelInputWrapper>
@@ -41,7 +49,7 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           max={ranges.c.max}
           step={ranges.c.step}
           value={+c.toFixed(ranges.c.precision)}
-          onChange={e => onChange(lch2color([l, +e.target.value, h]))}
+          onChange={e => setColor('c', +e.target.value)}
         />
       </ChannelInputWrapper>
       <ChannelInputWrapper>
@@ -52,7 +60,7 @@ export const ColorEditor: FC<ColorEditorProps> = ({ color, onChange }) => {
           max={ranges.h.max}
           step={ranges.h.step}
           value={+h.toFixed(ranges.h.precision)}
-          onChange={e => onChange(lch2color([l, c, +e.target.value]))}
+          onChange={e => setColor('h', +e.target.value)}
         />
       </ChannelInputWrapper>
       <HexInput

--- a/src/shared/colorFuncs/colorModels.ts
+++ b/src/shared/colorFuncs/colorModels.ts
@@ -18,9 +18,9 @@ export const cielch: TLchModel = {
   lch2xyz: (lch: LCH) => D50_to_D65(Lab_to_XYZ(LCH_to_Lab(lch))),
   xyz2lch: (xyz: XYZ) => Lab_to_LCH(XYZ_to_Lab(D65_to_D50(xyz))),
   ranges: {
-    l: { min: 0, max: 100, step: 0.5 },
-    c: { min: 0, max: 134, step: 0.5 },
-    h: { min: 0, max: 360, step: 0.5 },
+    l: { min: 0, max: 100, step: 0.5, precision: 2 },
+    c: { min: 0, max: 134, step: 0.5, precision: 2 },
+    h: { min: 0, max: 360, step: 0.5, precision: 2 },
   },
 }
 
@@ -30,9 +30,9 @@ export const oklch: TLchModel = {
     OKLab_to_XYZ(OKLCH_to_OKLab(fromDisplayOKLCH(lch))),
   xyz2lch: (xyz: XYZ): LCH => toDisplayOKLCH(OKLab_to_OKLCH(XYZ_to_OKLab(xyz))),
   ranges: {
-    l: { min: 0, max: 100, step: 0.5 },
-    c: { min: 0, max: 0.33, step: 0.005 },
-    h: { min: 0, max: 360, step: 0.5 },
+    l: { min: 0, max: 100, step: 0.5, precision: 2 },
+    c: { min: 0, max: 0.33, step: 0.005, precision: 3 },
+    h: { min: 0, max: 360, step: 0.5, precision: 2 },
   },
 }
 

--- a/src/shared/colorFuncs/index.ts
+++ b/src/shared/colorFuncs/index.ts
@@ -21,9 +21,9 @@ export const colorSpaces = {
 export type TLchModel = {
   name: spaceName
   ranges: {
-    l: { min: number; max: number; step: number }
-    c: { min: number; max: number; step: number }
-    h: { min: number; max: number; step: number }
+    l: { min: number; max: number; step: number; precision: number }
+    c: { min: number; max: number; step: number; precision: number }
+    h: { min: number; max: number; step: number; precision: number }
   }
   xyz2lch: (xyz: XYZ) => LCH
   lch2xyz: (lch: LCH) => XYZ


### PR DESCRIPTION
- The value labels for the graphs have been converted to input elements

- The labels for the selected color have a higher precision than the
  others. This makes it easier to see the difference when making
  adjustments using hotkeys.

- Clicking on a value label behaves the same as before, unless that color
  is already selected. In that case, the value is focused.

- Holding control while clicking a label always focuses it.

- When a value input is focused, the up/down arrow keys can be used to adjust the
  value.

- When an input is focused, pressing enter or escape will blur the input.