### PR TITLE
docs: copy selected text as oklch not lch

### DIFF
--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -69,8 +69,8 @@ const Hotkeys = () => {
         </li>
         <li>
           <MetaKey /> + <Key>⇧</Key> + <Key>C</Key> — copy selected color in{' '}
-          <Code>lch()</Code> format. Note that it has limited{' '}
-          <Link href="https://caniuse.com/css-lch-lab">browser support</Link>.
+          <Code>oklch()</Code> format. Note that it has limited{' '}
+          <Link href="https://caniuse.com/mdn-css_types_color_oklch">browser support</Link>.
         </li>
         <li>
           <MetaKey /> + <Key>V</Key> — paste color. Just copy color in any


### PR DESCRIPTION
### Change

- Tell use that shift copy gives `oklch` (not `lch`).
- Link user to browser support for `oklch` (not `lch`).

### Reason

When I use `shift + command + c`, I get `oklch(…)` value on my clipboard.